### PR TITLE
add connectionType to the bidRequest

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -25,8 +25,8 @@ const deviceConnection = {
 };
 
 const getConnextionType = () => {
-  const type = window.navigator.connection && (window.navigator.connection.type || window.navigator.connection.effectiveType)
-  switch (type) {
+  const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection || {}
+  switch (connection.type || connection.effectiveType) {
     case 'wifi':
     case 'ethernet':
       return deviceConnection.FIXED
@@ -34,8 +34,7 @@ const getConnextionType = () => {
     case 'wimax':
       return deviceConnection.MOBILE
     default:
-      const isMobile = (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window['MSStream']) ||
-        /android/i.test(navigator.userAgent)
+      const isMobile = /iPad|iPhone|iPod/.test(navigator.userAgent) || /android/i.test(navigator.userAgent)
       return isMobile ? deviceConnection.UNKNOWN : deviceConnection.FIXED
   }
 };

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -18,6 +18,28 @@ const mediaTypesMap = {
   [VIDEO]: 'video'
 };
 
+const deviceConnection = {
+  FIXED: 'fixed',
+  MOBILE: 'mobile',
+  UNKNOWN: 'unknown'
+};
+
+
+const getConnextionType = () => {
+  switch (connectionType) {
+    case 'wifi':
+    case "ethernet":
+      return deviceConnection.FIXED
+    case 'cellular':
+    case 'wimax':
+      return deviceConnection.MOBILE
+    default:
+      const isMobile = (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window['MSStream']) ||
+        /android/i.test(navigator.userAgent)
+      return isMobile ? deviceConnection.UNKNOWN : deviceConnection.FIXED
+  }
+};
+
 function mapMediaType(seedtagMediaType) {
   if (seedtagMediaType === 'display') return BANNER;
   if (seedtagMediaType === 'video') return VIDEO;
@@ -55,13 +77,15 @@ function buildBidRequests(validBidRequests) {
         return mediaTypesMap[pbjsType];
       }
     );
+
     const bidRequest = {
       id: validBidRequest.bidId,
       transactionId: validBidRequest.transactionId,
       sizes: validBidRequest.sizes,
       supplyTypes: mediaTypes,
       adUnitId: params.adUnitId,
-      placement: params.placement
+      placement: params.placement,
+      connectionType: getConnextionType()
     };
 
     if (params.adPosition) {
@@ -149,7 +173,7 @@ export const spec = {
       version: '$prebid.version$',
       bidRequests: buildBidRequests(validBidRequests)
     };
-
+    console.log(bidderRequest)
     if (payload.cmp) {
       const gdprApplies = bidderRequest.gdprConsent.gdprApplies;
       if (gdprApplies !== undefined) payload['ga'] = gdprApplies;

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -173,7 +173,7 @@ export const spec = {
       version: '$prebid.version$',
       bidRequests: buildBidRequests(validBidRequests)
     };
-    console.log(bidderRequest)
+
     if (payload.cmp) {
       const gdprApplies = bidderRequest.gdprConsent.gdprApplies;
       if (gdprApplies !== undefined) payload['ga'] = gdprApplies;

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -24,11 +24,11 @@ const deviceConnection = {
   UNKNOWN: 'unknown'
 };
 
-
 const getConnextionType = () => {
-  switch (connectionType) {
+  const type = window.navigator.connection && (window.navigator.connection.type || window.navigator.connection.effectiveType)
+  switch (type) {
     case 'wifi':
-    case "ethernet":
+    case 'ethernet':
       return deviceConnection.FIXED
     case 'cellular':
     case 'wimax':
@@ -85,7 +85,6 @@ function buildBidRequests(validBidRequests) {
       supplyTypes: mediaTypes,
       adUnitId: params.adUnitId,
       placement: params.placement,
-      connectionType: getConnextionType()
     };
 
     if (params.adPosition) {
@@ -171,6 +170,7 @@ export const spec = {
       cmp: !!bidderRequest.gdprConsent,
       timeout: bidderRequest.timeout,
       version: '$prebid.version$',
+      connectionType: getConnextionType(),
       bidRequests: buildBidRequests(validBidRequests)
     };
 

--- a/modules/seedtagBidAdapter.md
+++ b/modules/seedtagBidAdapter.md
@@ -57,6 +57,7 @@ var adUnits = [{
         adUnitId: '0000',               // required
         placement: 'video',             // required
         adPosition: 0,                  // optional
+        connectionType: 'mobile'        // optional (can be mobile/fixed/unknown)
         // Video object as specified in OpenRTB 2.5
         video: {
           mimes: ['video/mp4'], // recommended

--- a/modules/seedtagBidAdapter.md
+++ b/modules/seedtagBidAdapter.md
@@ -57,7 +57,6 @@ var adUnits = [{
         adUnitId: '0000',               // required
         placement: 'video',             // required
         adPosition: 0,                  // optional
-        connectionType: 'mobile'        // optional (can be mobile/fixed/unknown)
         // Video object as specified in OpenRTB 2.5
         video: {
           mimes: ['video/mp4'], // recommended

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -200,6 +200,7 @@ describe('Seedtag Adapter', function() {
       expect(data.url).to.equal('referer')
       expect(data.publisherToken).to.equal('0000-0000-01')
       expect(typeof data.version).to.equal('string')
+      expect(['fixed', 'mobile', 'unknown'].indexOf(data.connectionType)).to.be.above(-1)
     })
 
     describe('adPosition param', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This feature add a new optional parameter to our request payload : `connectionType` 

It send the connectionType value (ie networking) to our bid endpoint. the value can be `fixed`, `mobile` or `unknown`.
This parameter is not exposed to publisher, it's integral to our bidder
