### PR TITLE
Seedtag/allow creatives testing

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -82,7 +82,7 @@ function buildBidRequest(validBidRequest) {
     supplyTypes: mediaTypes,
     adUnitId: params.adUnitId,
     placement: params.placement,
-    requestCount: validBidRequest.bidderRequestsCount || 1 // FIXME : in unit test the parameter bidderRequestsCount is undefined
+    requestCount: validBidRequest.bidderRequestsCount || 1, // FIXME : in unit test the parameter bidderRequestsCount is undefined
   };
 
   if (params.adPosition) {
@@ -91,6 +91,11 @@ function buildBidRequest(validBidRequest) {
 
   if (hasVideoMediaType(validBidRequest)) {
     bidRequest.videoParams = getVideoParams(validBidRequest)
+  }
+
+  // check query params
+  if (params.testCreative) {
+    bidRequest.creative = params.testCreative
   }
 
   return bidRequest;
@@ -141,6 +146,26 @@ function buildBidResponse(seedtagBid) {
   return bid;
 }
 
+function getOveriddenCreative(referrerUrl) {
+  const url = new URL(referrerUrl)
+  const creativeParam = url.searchParams.get('pbjs_seedtag_creativeParam')
+  if (creativeParam) {
+    const parts = creativeParam.split(':')
+
+    if (parts > 1) {
+      return {
+        adUnitId: parts[0],
+        creative: parts[1]
+      }
+    } else {
+      return {
+        adUnitId: null,
+        creative: parts
+      }
+    }
+  }
+}
+
 export function getTimeoutUrl (data) {
   let queryParams = '';
   if (
@@ -178,6 +203,7 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests(validBidRequests, bidderRequest) {
+    const creative = getOveriddenCreative(bidderRequest.refererInfo.referer)
     const payload = {
       url: bidderRequest.refererInfo.referer,
       publisherToken: validBidRequests[0].params.publisherId,
@@ -185,7 +211,14 @@ export const spec = {
       timeout: bidderRequest.timeout,
       version: '$prebid.version$',
       connectionType: getConnectionType(),
-      bidRequests: utils._map(validBidRequests, buildBidRequest)
+      bidRequests: utils._map(validBidRequests, (validBidRequest) => {
+        const bid = buildBidRequest(validBidRequest)
+
+        // force a creative with url params
+        if (creative && (!creative.adUnitId || creative.adUnitId === bid.adUnitId)) {
+          bid.testCreative = creative.creative
+        }
+      })
     };
 
     if (payload.cmp) {

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -95,7 +95,7 @@ function buildBidRequest(validBidRequest) {
 
   // check query params
   if (params.testCreative) {
-    bidRequest.creative = params.testCreative
+    bidRequest.testCreative = params.testCreative
   }
 
   return bidRequest;
@@ -146,26 +146,28 @@ function buildBidResponse(seedtagBid) {
   return bid;
 }
 
-export const testCreativeParam = 'pbjs_seedtag_creative'
+export const forceCreativeFromUrlParam = 'pbjs_seedtag_creative'
 
 function getOveriddenCreative(referrerUrl) {
-  const url = new URL(referrerUrl)
-  const creativeParam = url.searchParams.get(testCreativeParam)
-  if (creativeParam) {
-    const parts = creativeParam.split(':')
+  try {
+    const url = new URL(referrerUrl)
+    const creativeParam = url.searchParams.get(forceCreativeFromUrlParam)
+    if (creativeParam) {
+      const parts = creativeParam.split(':')
 
-    if (parts > 1 && parts[0] !== 'adtag') {
-      return {
-        adUnitId: parts[0],
-        creative: parts.slice(1).join(':')
-      }
-    } else {
-      return {
-        adUnitId: null,
-        creative: parts.join(':')
+      if (parts.length > 1 && parts[0] !== 'adtag') {
+        return {
+          adUnitId: parts[0],
+          creative: parts.slice(1).join(':')
+        }
+      } else {
+        return {
+          adUnitId: null,
+          creative: parts.join(':')
+        }
       }
     }
-  }
+  } catch (e) { }
 }
 
 export function getTimeoutUrl (data) {
@@ -220,6 +222,8 @@ export const spec = {
         if (creative && (!creative.adUnitId || creative.adUnitId === bid.adUnitId)) {
           bid.testCreative = creative.creative
         }
+
+        return bid
       })
     };
 

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -155,7 +155,7 @@ function getOveriddenCreative(referrerUrl) {
     if (creativeParam) {
       const parts = creativeParam.split(':')
 
-      if (parts.length > 1 && parts[0] !== 'adtag') {
+      if (parts.length > 1 && ['video', 'display'].indexOf(parts[0]) === -1) {
         return {
           adUnitId: parts[0],
           creative: parts.slice(1).join(':')

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -146,21 +146,23 @@ function buildBidResponse(seedtagBid) {
   return bid;
 }
 
+export const testCreativeParam = 'pbjs_seedtag_creative'
+
 function getOveriddenCreative(referrerUrl) {
   const url = new URL(referrerUrl)
-  const creativeParam = url.searchParams.get('pbjs_seedtag_creativeParam')
+  const creativeParam = url.searchParams.get(testCreativeParam)
   if (creativeParam) {
     const parts = creativeParam.split(':')
 
-    if (parts > 1) {
+    if (parts > 1 && parts[0] !== 'adtag') {
       return {
         adUnitId: parts[0],
-        creative: parts[1]
+        creative: parts.slice(1).join(':')
       }
     } else {
       return {
         adUnitId: null,
-        creative: parts
+        creative: parts.join(':')
       }
     }
   }

--- a/modules/seedtagBidAdapter.md
+++ b/modules/seedtagBidAdapter.md
@@ -146,4 +146,5 @@ http://publisherpage.com/article?pbjs_seedtag_creative=display-open-300x250
 | video-direct-fiv | 600x600 |
 | video-direct-piv | 600x600 |
 | video-open-piv | 600x600 |
-| adtag:[id] | - |
+| video:[adtagId] | 600x600 |
+| display:[adtagId] | 600x600 |

--- a/modules/seedtagBidAdapter.md
+++ b/modules/seedtagBidAdapter.md
@@ -90,3 +90,60 @@ var adUnits = [{
   ]
 }];
 ```
+
+## Force testing a creative
+In order to see how formats look like, you can test them with adunit config, or with url directly.
+
+### With adunit config
+This is just for testing, remove it before go to production
+```
+[
+  {
+    code: '/21804003197/prebid_test_300x250',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    bids: [
+      {
+        bidder: 'seedtag',
+        params: {
+          ...,
+          testCreative: "display-open-300x250"
+        }
+      }
+    ]
+  }
+]
+```
+
+### With url params
+Just add this parameter to the publisher page : 
+http://publisherpage.com/article?pbjs_seedtag_creative=display-open-300x250
+
+### Available creative for test
+| value | size |
+| ----- | ---- |
+| display-open-120x600 | 120x600 |
+| display-open-160x600 | 160x600 |
+| display-open-250x250 | 250x250 |
+| display-open-300x50 | 300x50 |
+| display-open-300x250 | 300x250 |
+| display-open-300x600 | 300x600 |
+| display-open-320x50 | 320x50 |
+| display-open-320x100 | 320x100 |
+| display-open-320x480 | 320x480 |
+| display-open-336x280 | 336x280 |
+| display-open-468x60 | 468x60 |
+| display-open-728x90 | 728x90 |
+| display-open-970x90 | 970x90 |
+| display-open-970x250 | 970x250 |
+| display-open-970x300 | 970x300 |
+| display-open-980x90 | 980x90 |
+| display-open-980x250 | 980x250 |
+| display-direct-fid | 600x600 |
+| video-direct-fiv | 600x600 |
+| video-direct-piv | 600x600 |
+| video-open-piv | 600x600 |
+| adtag:[id] | - |

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { spec, getTimeoutUrl } from 'modules/seedtagBidAdapter.js'
+import { spec, getTimeoutUrl, testCreativeParam } from 'modules/seedtagBidAdapter.js'
 import * as utils from 'src/utils.js'
 
 const PUBLISHER_ID = '0000-0000-01'
@@ -293,7 +293,6 @@ describe('Seedtag Adapter', function() {
         expect(bannerBid.sizes[1][0]).to.equal(300)
         expect(bannerBid.sizes[1][1]).to.equal(600)
         expect(bannerBid.requestCount).to.equal(1)
-        expect(bannerBid.testCreative).to.equal('creative')
       })
       it('should request an InStream Video', function() {
         const videoBid = bidRequests[1]
@@ -311,7 +310,6 @@ describe('Seedtag Adapter', function() {
         expect(videoBid.sizes[1][0]).to.equal(300)
         expect(videoBid.sizes[1][1]).to.equal(600)
         expect(videoBid.requestCount).to.equal(1)
-        expect(bannerBid.testCreative).to.equal('undefined')
       })
     })
 
@@ -321,7 +319,7 @@ describe('Seedtag Adapter', function() {
           ...bidderRequest,
           refererInfo: {
             ...refererInfo,
-            referer: 'http://referer.com/?seedtag_test_creative=000000:creative'
+            referer: 'http://referer.com/?' + testCreativeParam + '=000000:creative'
           }
         }
         const request = spec.buildRequests(validBidRequests, bidderRequest)
@@ -337,7 +335,7 @@ describe('Seedtag Adapter', function() {
           ...bidderRequest,
           refererInfo: {
             ...refererInfo,
-            referer: 'http://referer.com/?seedtag_test_creative=creative'
+            referer: 'http://referer.com/?' + testCreativeParam + '=creative'
           }
         }
         const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
@@ -379,7 +377,7 @@ describe('Seedtag Adapter', function() {
           ...bidderRequest,
           refererInfo: {
             ...refererInfo,
-            referer: 'http://referer.com/?seedtag_test_creative=00000:creative'
+            referer: 'http://referer.com/?' + testCreativeParam + '=00000:creative'
           }
         }
         const request = spec.buildRequests(updatedValidBidRequests, updatedBidderRequest)
@@ -399,7 +397,7 @@ describe('Seedtag Adapter', function() {
           ...bidderRequest,
           refererInfo: {
             ...refererInfo,
-            referer: 'http://referer.com/?seedtag_test_creative=creative2'
+            referer: 'http://referer.com/?' + testCreativeParam + '=creative2'
           }
         }
         const request = spec.buildRequests(updatedValidBidRequests, updatedBidderRequest)
@@ -408,6 +406,38 @@ describe('Seedtag Adapter', function() {
 
         expect(bidRequests[0].testCreative).to.equal('creative2')
         expect(bidRequests[1].testCreative).to.equal('creative2')
+      })
+
+      it('should handle adtag as creative for a specific adunit', function () {
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...refererInfo,
+            referer: 'http://referer.com/?' + testCreativeParam + '=000000:adtag:xxxxxx'
+          }
+        }
+        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('adtag:xxxxxx')
+        expect(bidRequests[1].testCreative).to.equal(undefined)
+      })
+
+      it('should handle adtag as creative for all adunits', function () {
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...refererInfo,
+            referer: 'http://referer.com/?' + testCreativeParam + '=adtag:xxxxxx'
+          }
+        }
+        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('adtag:xxxxxx')
+        expect(bidRequests[1].testCreative).to.equal('adtag:xxxxxx')
       })
     })
   })

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -186,7 +186,7 @@ describe('Seedtag Adapter', function() {
 
   describe('buildRequests method', function() {
     const bidderRequest = {
-      refererInfo: { referer: 'referer' },
+      refererInfo: { referer: 'http://referer' },
       timeout: 1000
     }
     const mandatoryParams = {
@@ -197,7 +197,8 @@ describe('Seedtag Adapter', function() {
     const inStreamParams = Object.assign({}, mandatoryParams, {
       video: {
         mimes: 'mp4'
-      }
+      },
+      adUnitId: ADUNIT_ID + '1'
     })
     const validBidRequests = [
       getSlotConfigs({ banner: {} }, mandatoryParams),
@@ -215,7 +216,7 @@ describe('Seedtag Adapter', function() {
     it('Common data request should be correct', function() {
       const request = spec.buildRequests(validBidRequests, bidderRequest)
       const data = JSON.parse(request.data)
-      expect(data.url).to.equal('referer')
+      expect(data.url).to.equal('http://referer')
       expect(data.publisherToken).to.equal('0000-0000-01')
       expect(typeof data.version).to.equal('string')
       expect(['fixed', 'mobile', 'unknown'].indexOf(data.connectionType)).to.be.above(-1)
@@ -292,6 +293,7 @@ describe('Seedtag Adapter', function() {
         expect(bannerBid.sizes[1][0]).to.equal(300)
         expect(bannerBid.sizes[1][1]).to.equal(600)
         expect(bannerBid.requestCount).to.equal(1)
+        expect(bannerBid.testCreative).to.equal('creative')
       })
       it('should request an InStream Video', function() {
         const videoBid = bidRequests[1]
@@ -300,7 +302,7 @@ describe('Seedtag Adapter', function() {
           'd704d006-0d6e-4a09-ad6c-179e7e758096'
         )
         expect(videoBid.supplyTypes[0]).to.equal('video')
-        expect(videoBid.adUnitId).to.equal('000000')
+        expect(videoBid.adUnitId).to.equal('0000001')
         expect(videoBid.videoParams.mimes).to.equal('mp4')
         expect(videoBid.videoParams.w).to.equal(300)
         expect(videoBid.videoParams.h).to.equal(200)
@@ -309,6 +311,103 @@ describe('Seedtag Adapter', function() {
         expect(videoBid.sizes[1][0]).to.equal(300)
         expect(videoBid.sizes[1][1]).to.equal(600)
         expect(videoBid.requestCount).to.equal(1)
+        expect(bannerBid.testCreative).to.equal('undefined')
+      })
+    })
+
+    describe('test creatives', function () {
+      it('should have a test creative for only for a specific adunit when overrided with url', function () {
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...refererInfo,
+            referer: 'http://referer.com/?seedtag_test_creative=000000:creative'
+          }
+        }
+        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('creative')
+        expect(bidRequests[1].testCreative).to.equal(undefined)
+      })
+
+      it('should have a test creative for all adunit when overrided with url', function () {
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...refererInfo,
+            referer: 'http://referer.com/?seedtag_test_creative=creative'
+          }
+        }
+        const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('creative')
+        expect(bidRequests[1].testCreative).to.equal('creative')
+      })
+
+      it('shouldn\'t have a test creative when nothing is specified on the url', function () {
+        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal(undefined)
+        expect(bidRequests[1].testCreative).to.equal(undefined)
+      })
+
+      it('Should have a test creative when specified on the adunit config', function () {
+        const updatedValidBidRequests = {
+          ...validBidRequests,
+        }
+        updatedValidBidRequests.bids[0].params.testCreative = 'creative'
+        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('creative')
+        expect(bidRequests[1].testCreative).to.equal(undefined)
+      })
+
+      it('Should override the test creative specified on the adunit config when using url', function () {
+        const updatedValidBidRequests = {
+          ...validBidRequests,
+        }
+        updatedValidBidRequests.bids[0].params.testCreative = 'creative'
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...refererInfo,
+            referer: 'http://referer.com/?seedtag_test_creative=00000:creative'
+          }
+        }
+        const request = spec.buildRequests(updatedValidBidRequests, updatedBidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('creative')
+        expect(bidRequests[1].testCreative).to.equal(undefined)
+      })
+
+      it('Should override the test creative specified on all adunit config when using url', function () {
+        const updatedValidBidRequests = {
+          ...validBidRequests,
+        }
+        updatedValidBidRequests.bids[0].params.testCreative = 'creative'
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...refererInfo,
+            referer: 'http://referer.com/?seedtag_test_creative=creative2'
+          }
+        }
+        const request = spec.buildRequests(updatedValidBidRequests, updatedBidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('creative2')
+        expect(bidRequests[1].testCreative).to.equal('creative2')
       })
     })
   })

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -408,19 +408,35 @@ describe('Seedtag Adapter', function() {
         expect(bidRequests[1].testCreative).to.equal('creative2')
       })
 
-      it('should handle adtag as creative for a specific adunit', function () {
+      it('should handle video:adtagId creative for a specific adunit', function () {
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
             ...bidderRequest.refererInfo,
-            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=' + ADUNIT_ID + ':adtag:xxxxxx'
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=' + ADUNIT_ID + ':video:xxxxxx'
           }
         }
         const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
         const data = JSON.parse(request.data)
         const bidRequests = data.bidRequests
 
-        expect(bidRequests[0].testCreative).to.equal('adtag:xxxxxx')
+        expect(bidRequests[0].testCreative).to.equal('video:xxxxxx')
+        expect(bidRequests[1].testCreative).to.equal(undefined)
+      })
+
+      it('should handle display::adtagId as display creative for a specific adunit', function () {
+        const updatedBidderRequest = {
+          ...bidderRequest,
+          refererInfo: {
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=' + ADUNIT_ID + ':display:xxxxxx'
+          }
+        }
+        const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
+        const data = JSON.parse(request.data)
+        const bidRequests = data.bidRequests
+
+        expect(bidRequests[0].testCreative).to.equal('display:xxxxxx')
         expect(bidRequests[1].testCreative).to.equal(undefined)
       })
 
@@ -429,15 +445,15 @@ describe('Seedtag Adapter', function() {
           ...bidderRequest,
           refererInfo: {
             ...bidderRequest.refererInfo,
-            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=adtag:xxxxxx'
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=video:xxxxxx'
           }
         }
         const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
         const data = JSON.parse(request.data)
         const bidRequests = data.bidRequests
 
-        expect(bidRequests[0].testCreative).to.equal('adtag:xxxxxx')
-        expect(bidRequests[1].testCreative).to.equal('adtag:xxxxxx')
+        expect(bidRequests[0].testCreative).to.equal('video:xxxxxx')
+        expect(bidRequests[1].testCreative).to.equal('video:xxxxxx')
       })
     })
   })

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { spec, getTimeoutUrl, testCreativeParam } from 'modules/seedtagBidAdapter.js'
+import { spec, getTimeoutUrl, forceCreativeFromUrlParam } from 'modules/seedtagBidAdapter.js'
 import * as utils from 'src/utils.js'
 
 const PUBLISHER_ID = '0000-0000-01'
@@ -287,7 +287,7 @@ describe('Seedtag Adapter', function() {
           'd704d006-0d6e-4a09-ad6c-179e7e758096'
         )
         expect(bannerBid.supplyTypes[0]).to.equal('display')
-        expect(bannerBid.adUnitId).to.equal('000000')
+        expect(bannerBid.adUnitId).to.equal(ADUNIT_ID)
         expect(bannerBid.sizes[0][0]).to.equal(300)
         expect(bannerBid.sizes[0][1]).to.equal(250)
         expect(bannerBid.sizes[1][0]).to.equal(300)
@@ -301,7 +301,7 @@ describe('Seedtag Adapter', function() {
           'd704d006-0d6e-4a09-ad6c-179e7e758096'
         )
         expect(videoBid.supplyTypes[0]).to.equal('video')
-        expect(videoBid.adUnitId).to.equal('0000001')
+        expect(videoBid.adUnitId).to.equal(ADUNIT_ID + '1')
         expect(videoBid.videoParams.mimes).to.equal('mp4')
         expect(videoBid.videoParams.w).to.equal(300)
         expect(videoBid.videoParams.h).to.equal(200)
@@ -318,11 +318,11 @@ describe('Seedtag Adapter', function() {
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
-            ...refererInfo,
-            referer: 'http://referer.com/?' + testCreativeParam + '=000000:creative'
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=' + ADUNIT_ID + ':creative'
           }
         }
-        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
         const data = JSON.parse(request.data)
         const bidRequests = data.bidRequests
 
@@ -334,8 +334,8 @@ describe('Seedtag Adapter', function() {
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
-            ...refererInfo,
-            referer: 'http://referer.com/?' + testCreativeParam + '=creative'
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=creative'
           }
         }
         const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
@@ -359,8 +359,8 @@ describe('Seedtag Adapter', function() {
         const updatedValidBidRequests = {
           ...validBidRequests,
         }
-        updatedValidBidRequests.bids[0].params.testCreative = 'creative'
-        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        updatedValidBidRequests[0].params.testCreative = 'creative'
+        const request = spec.buildRequests(updatedValidBidRequests, bidderRequest)
         const data = JSON.parse(request.data)
         const bidRequests = data.bidRequests
 
@@ -372,12 +372,12 @@ describe('Seedtag Adapter', function() {
         const updatedValidBidRequests = {
           ...validBidRequests,
         }
-        updatedValidBidRequests.bids[0].params.testCreative = 'creative'
+        updatedValidBidRequests[0].params.testCreative = 'creative'
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
-            ...refererInfo,
-            referer: 'http://referer.com/?' + testCreativeParam + '=00000:creative'
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=00000:creative'
           }
         }
         const request = spec.buildRequests(updatedValidBidRequests, updatedBidderRequest)
@@ -392,12 +392,12 @@ describe('Seedtag Adapter', function() {
         const updatedValidBidRequests = {
           ...validBidRequests,
         }
-        updatedValidBidRequests.bids[0].params.testCreative = 'creative'
+        updatedValidBidRequests[0].params.testCreative = 'creative'
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
-            ...refererInfo,
-            referer: 'http://referer.com/?' + testCreativeParam + '=creative2'
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=creative2'
           }
         }
         const request = spec.buildRequests(updatedValidBidRequests, updatedBidderRequest)
@@ -412,11 +412,11 @@ describe('Seedtag Adapter', function() {
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
-            ...refererInfo,
-            referer: 'http://referer.com/?' + testCreativeParam + '=000000:adtag:xxxxxx'
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=' + ADUNIT_ID + ':adtag:xxxxxx'
           }
         }
-        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
         const data = JSON.parse(request.data)
         const bidRequests = data.bidRequests
 
@@ -428,11 +428,11 @@ describe('Seedtag Adapter', function() {
         const updatedBidderRequest = {
           ...bidderRequest,
           refererInfo: {
-            ...refererInfo,
-            referer: 'http://referer.com/?' + testCreativeParam + '=adtag:xxxxxx'
+            ...bidderRequest.refererInfo,
+            referer: 'http://referer.com/?' + forceCreativeFromUrlParam + '=adtag:xxxxxx'
           }
         }
-        const request = spec.buildRequests(validBidRequests, bidderRequest)
+        const request = spec.buildRequests(validBidRequests, updatedBidderRequest)
         const data = JSON.parse(request.data)
         const bidRequests = data.bidRequests
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Allow to force our SSP to return a default creative for testing and validation.

The list of possible creatives to test is in the readme

can be used through bidder params or url (@see modules/seedtagBidAdapter.md)